### PR TITLE
Add Bluetooth rumble support for Stadia controllers

### DIFF
--- a/libstadia/include/stadia.h
+++ b/libstadia/include/stadia.h
@@ -53,6 +53,8 @@ struct stadia_controller
 {
     struct hid_device *device;
 
+    BOOL bluetooth;
+
     SRWLOCK state_lock;
     struct stadia_state state;
 

--- a/libstadia/src/stadia.c
+++ b/libstadia/src/stadia.c
@@ -5,6 +5,7 @@
 #include "stadia.h"
 
 #include "hid.h"
+#include "utils.h"
 
 #include <stdio.h>
 #include <synchapi.h>
@@ -113,24 +114,50 @@ static DWORD WINAPI _stadia_output_thread(LPVOID lparam)
 
         ReleaseSRWLockShared(&controller->vibration_lock);
 
-        hid_send_output_report(controller->device, vibration, sizeof(vibration), STADIA_READ_TIMEOUT);
+        INT result;
+        if (controller->bluetooth)
+        {
+            result = hid_send_feature_report(controller->device, vibration, sizeof(vibration));
+        }
+        else
+        {
+            result = hid_send_output_report(controller->device, vibration, sizeof(vibration), STADIA_READ_TIMEOUT);
+        }
+        printf("send vibration small=%u big=%u ret=%d via %s\n", vibration[4], vibration[2], result,
+               controller->bluetooth ? "bt" : "usb");
 
         ResetEvent(controller->output_event);
     }
 
-    hid_send_output_report(controller->device, init_vibration, sizeof(init_vibration), STADIA_READ_TIMEOUT);
+    if (controller->bluetooth)
+    {
+        hid_send_feature_report(controller->device, init_vibration, sizeof(init_vibration));
+    }
+    else
+    {
+        hid_send_output_report(controller->device, init_vibration, sizeof(init_vibration), STADIA_READ_TIMEOUT);
+    }
 
     return 0;
 }
 
 struct stadia_controller *stadia_controller_create(struct hid_device *device)
 {
-    if (!hid_send_output_report(device, init_vibration, sizeof(init_vibration), STADIA_READ_TIMEOUT) <= 0)
+    BOOL bluetooth = _tcsistr(device->path, STADIA_BLT_HW_FILTER) != NULL;
+
+    if (bluetooth)
     {
-        last_error = STADIA_ERROR_VIBRATION_INIT_FAILURE;
-        // Don't error out for now.
-        // TODO: Fix vibration for bluetooth controllers.
-        //return NULL;
+        if (hid_send_feature_report(device, init_vibration, sizeof(init_vibration)) <= 0)
+        {
+            last_error = STADIA_ERROR_VIBRATION_INIT_FAILURE;
+        }
+    }
+    else
+    {
+        if (hid_send_output_report(device, init_vibration, sizeof(init_vibration), STADIA_READ_TIMEOUT) <= 0)
+        {
+            last_error = STADIA_ERROR_VIBRATION_INIT_FAILURE;
+        }
     }
 
     SECURITY_ATTRIBUTES security = {.nLength = sizeof(SECURITY_ATTRIBUTES),
@@ -139,6 +166,7 @@ struct stadia_controller *stadia_controller_create(struct hid_device *device)
 
     struct stadia_controller *controller = (struct stadia_controller *)malloc(sizeof(struct stadia_controller));
     controller->device = device;
+    controller->bluetooth = bluetooth;
     controller->active = TRUE;
 
     // Create locks.


### PR DESCRIPTION
## Summary
- Enable Stadia controller rumble when connected over Bluetooth by sending vibration data via feature reports
- Detect connection type and retain existing USB vibration behavior
- Add debug logging for vibration commands

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `gcc libstadia/src/*.c -I libstadia/include -o /tmp/test` *(fails: wtypes.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b870b0321483299ba1a792991fabbd