### PR TITLE
Ensure logs appear when launching from Command Prompt

### DIFF
--- a/libstadia/include/stadia.h
+++ b/libstadia/include/stadia.h
@@ -53,6 +53,8 @@ struct stadia_controller
 {
     struct hid_device *device;
 
+    BOOL bluetooth;
+
     SRWLOCK state_lock;
     struct stadia_state state;
 

--- a/stadia-vigem/src/main.c
+++ b/stadia-vigem/src/main.c
@@ -37,6 +37,19 @@ static BOOL vigem_connected = FALSE;
 
 static struct tray_menu tray_menu_device_count;
 
+static void attach_parent_console()
+{
+    if (AttachConsole(ATTACH_PARENT_PROCESS))
+    {
+        FILE *fp;
+        fp = freopen("CONOUT$", "w", stdout);
+        fp = freopen("CONOUT$", "w", stderr);
+        fp = freopen("CONIN$", "r", stdin);
+        setvbuf(stdout, NULL, _IONBF, 0);
+        setvbuf(stderr, NULL, _IONBF, 0);
+    }
+}
+
 // future declarations
 static void stadia_controller_update_cb(struct stadia_controller *controller, struct stadia_state *state);
 static void stadia_controller_stop_cb(struct stadia_controller *controller);
@@ -360,6 +373,7 @@ static void quit_cb(struct tray_menu *item)
 
 INT main()
 {
+    attach_parent_console();
     rebuild_tray_menu();
     if (tray_init(&tray) < 0)
     {


### PR DESCRIPTION
## Summary
- attach to parent console on startup so stdout/stderr logs are visible

## Testing
- `x86_64-w64-mingw32-gcc -c stadia-vigem/src/main.c -I libstadia/include -I stadia-vigem/include -I ViGEmClient/include -o /tmp/main.o`
- `x86_64-w64-mingw32-gcc -c libstadia/src/stadia.c -I libstadia/include -o /tmp/stadia.o`


------
https://chatgpt.com/codex/tasks/task_e_68b870b0321483299ba1a792991fabbd