### PR TITLE
Fix Bluetooth vibration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stadia-ViGEm
 
-Xbox 360 controller emulation for Stadia controller. Supports controllers connected via USB & bluetooth. Supports multiple devices and vibration (wired only). Forked from Mi-ViGEm (https://github.com/grayver/Mi-ViGEm) by grayver.
+Xbox 360 controller emulation for Stadia controller. Supports controllers connected via USB & bluetooth. Supports multiple devices and vibration. Forked from Mi-ViGEm (https://github.com/grayver/Mi-ViGEm) by grayver.
 Xbox 360 controller emulation driver is provided by ViGEm (https://github.com/ViGEm/ViGEmBus), by Benjamin Höglinger.
 
 ## Requirements

--- a/libstadia/src/stadia.c
+++ b/libstadia/src/stadia.c
@@ -118,29 +118,14 @@ static DWORD WINAPI _stadia_output_thread(LPVOID lparam)
 
         ReleaseSRWLockShared(&controller->vibration_lock);
 
-        INT result;
-        if (controller->bluetooth)
-        {
-            result = hid_send_feature_report(controller->device, vibration, sizeof(vibration));
-        }
-        else
-        {
-            result = hid_send_output_report(controller->device, vibration, sizeof(vibration), STADIA_READ_TIMEOUT);
-        }
+        INT result = hid_send_output_report(controller->device, vibration, sizeof(vibration), STADIA_READ_TIMEOUT);
         printf("send vibration small=%u big=%u ret=%d via %s\n", vibration[4], vibration[2], result,
                controller->bluetooth ? "bt" : "usb");
 
         ResetEvent(controller->output_event);
     }
 
-    if (controller->bluetooth)
-    {
-        hid_send_feature_report(controller->device, init_vibration, sizeof(init_vibration));
-    }
-    else
-    {
-        hid_send_output_report(controller->device, init_vibration, sizeof(init_vibration), STADIA_READ_TIMEOUT);
-    }
+    hid_send_output_report(controller->device, init_vibration, sizeof(init_vibration), STADIA_READ_TIMEOUT);
 
     return 0;
 }
@@ -149,19 +134,9 @@ struct stadia_controller *stadia_controller_create(struct hid_device *device)
 {
     BOOL bluetooth = _tcsistr(device->path, STADIA_BLT_HW_FILTER) != NULL;
 
-    if (bluetooth)
+    if (hid_send_output_report(device, init_vibration, sizeof(init_vibration), STADIA_READ_TIMEOUT) <= 0)
     {
-        if (hid_send_feature_report(device, init_vibration, sizeof(init_vibration)) <= 0)
-        {
-            last_error = STADIA_ERROR_VIBRATION_INIT_FAILURE;
-        }
-    }
-    else
-    {
-        if (hid_send_output_report(device, init_vibration, sizeof(init_vibration), STADIA_READ_TIMEOUT) <= 0)
-        {
-            last_error = STADIA_ERROR_VIBRATION_INIT_FAILURE;
-        }
+        last_error = STADIA_ERROR_VIBRATION_INIT_FAILURE;
     }
 
     SECURITY_ATTRIBUTES security = {.nLength = sizeof(SECURITY_ATTRIBUTES),


### PR DESCRIPTION
## Summary
- send Stadia vibration reports over the output channel for all connections to support Bluetooth
- initialize vibration state uniformly using output reports
- update documentation to reflect Bluetooth vibration support

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f12abfadc8329a50f8e60e544a0ba)